### PR TITLE
Fix conversion matrices in CSC and RGBC modules

### DIFF
--- a/modules/color_space_conversion/color_space_conversion.py
+++ b/modules/color_space_conversion/color_space_conversion.py
@@ -43,14 +43,14 @@ class ColorSpaceConversion:
         if self.conv_std == 1:
             # for BT. 709
             self.rgb2yuv_mat = np.array(
-                [[54, 182, 18], [-29, -98, 128], [128, -116, -12]]
+                [[47, 157, 16], [-26, -86, 112], [112, -102, -10]]
             )
         else:
 
             # for BT.601/407
             # conversion metrix with 8bit integer co-efficients - m=8
             self.rgb2yuv_mat = np.array(
-                [[77, 150, 29], [-43, -84, 128], [128, -107, -21]]
+                [[77, 150, 29], [-43, -85, 128], [128, -107, -21]]
             )
 
         # make nx3 2d matrix of image
@@ -77,7 +77,8 @@ class ColorSpaceConversion:
 
 
         # black-level/DC offset added to YUV values
-        yuv_2d[0, :] = 2 ** (self.bit_depth / 2) + yuv_2d[0, :]
+        if self.conv_std == 1:
+            yuv_2d[0, :] = 2 ** (self.bit_depth / 2) + yuv_2d[0, :]
         yuv_2d[1, :] = 2 ** (self.bit_depth - 1) + yuv_2d[1, :]
         yuv_2d[2, :] = 2 ** (self.bit_depth - 1) + yuv_2d[2, :]
 

--- a/modules/color_space_conversion/color_space_conversion.py
+++ b/modules/color_space_conversion/color_space_conversion.py
@@ -43,14 +43,14 @@ class ColorSpaceConversion:
         if self.conv_std == 1:
             # for BT. 709
             self.rgb2yuv_mat = np.array(
-                [[47, 157, 16], [-26, -86, 112], [112, -102, -10]]
+                [[54, 182, 18], [-29, -98, 128], [128, -116, -12]]
             )
         else:
 
             # for BT.601/407
             # conversion metrix with 8bit integer co-efficients - m=8
             self.rgb2yuv_mat = np.array(
-                [[77, 150, 29], [-44, -87, 138], [131, -110, -21]]
+                [[77, 150, 29], [-43, -84, 128], [128, -107, -21]]
             )
 
         # make nx3 2d matrix of image

--- a/modules/rgb_conversion/rgb_conversion.py
+++ b/modules/rgb_conversion/rgb_conversion.py
@@ -50,13 +50,13 @@ class RGBConversion:
         # subract the offsets
         mat2d_t = mat2d_t - np.array([[16, 128, 128]]).transpose()
 
-        if self.conv_std == 1:
+       if self.conv_std == 1:
             # for BT. 709
-            self.yuv2rgb_mat = np.array([[74, 0, 114], [74, -13, -34], [74, 135, 0]])
+            self.yuv2rgb_mat = np.array([[69, 0, 109], [69, -13, -32], [69, 128, 0]])
         else:
             # for BT.601/407
             # conversion metrix with 8bit integer co-efficients - m=8
-            self.yuv2rgb_mat = np.array([[64, 0, 87], [64, -20, -44], [61, 105, 0]])
+            self.yuv2rgb_mat = np.array([[72, 0, 101], [72, -25, -52], [72, 128, 0]])
 
         # convert to RGB
         rgb_2d = np.matmul(self.yuv2rgb_mat, mat2d_t)

--- a/modules/rgb_conversion/rgb_conversion.py
+++ b/modules/rgb_conversion/rgb_conversion.py
@@ -47,16 +47,17 @@ class RGBConversion:
         # convert to 3xn for matrix multiplication
         mat2d_t = mat_2d.transpose()
 
-        # subract the offsets
-        mat2d_t = mat2d_t - np.array([[16, 128, 128]]).transpose()
-
-       if self.conv_std == 1:
+        if self.conv_std == 1:
             # for BT. 709
-            self.yuv2rgb_mat = np.array([[69, 0, 109], [69, -13, -32], [69, 128, 0]])
+            # subract the offsets
+            mat2d_t = mat2d_t - np.array([[16, 128, 128]]).transpose()
+            self.yuv2rgb_mat = np.array([[74, 0, 114], [74, -13, -34], [74, 135, 0]])
         else:
             # for BT.601/407
             # conversion metrix with 8bit integer co-efficients - m=8
-            self.yuv2rgb_mat = np.array([[72, 0, 101], [72, -25, -52], [72, 128, 0]])
+            # subract the offsets
+            mat2d_t = mat2d_t - np.array([[0, 128, 128]]).transpose()
+            self.yuv2rgb_mat = np.array([[64, 0, 90], [64, -22, -46], [64, 113, 0]])
 
         # convert to RGB
         rgb_2d = np.matmul(self.yuv2rgb_mat, mat2d_t)


### PR DESCRIPTION
Fixes #46 

Correct math and matrices are explained in the following slides:
[CSC_and_RGB_conversion.pptx](https://github.com/user-attachments/files/26539023/CSC_and_RGB_conversion.pptx)
